### PR TITLE
Fft pad

### DIFF
--- a/zkml/src/onnx_parse.rs
+++ b/zkml/src/onnx_parse.rs
@@ -477,7 +477,6 @@ pub fn load_model<Q: Quantizer<Element>>(filepath: &str) -> Result<Model> {
                 input_shape_og = vec![input_shape_og.iter().product()];
                 assert!(input_shape_padded.iter().all(|d| d.is_power_of_two()));
                 input_shape_padded = vec![input_shape_padded.iter().product()];
-                // TODO: Pad dense layer to remove junk/garbage FFT values from Conv
             }
             _ => bail!("Unsupported operation"),
         };

--- a/zkml/src/tensor.rs
+++ b/zkml/src/tensor.rs
@@ -1278,6 +1278,14 @@ where
         }
     }
 
+    // Pads a matrix `M` to `M'` so that matrix-vector multiplication with a flattened FFT-padded convolution output `X'`
+    /// matches the result of multiplying `M` with the original convolution output `X`.
+    ///
+    /// The real convolution output `X` has dimensions `(C, H, W)`. However, when using FFT-based convolution,
+    /// the output `X'` is padded to dimensions `(C', H', W')`, where `C'`, `H'`, and `W'` are the next power of 2
+    /// greater than or equal to `C`, `H`, and `W`, respectively.
+    /// Given a matrix `M` designed to multiply with the flattened `X`, this function pads `M` into `M'` such that
+    /// `M * X == M' * X'`, ensuring the result remains consistent despite the padding in `X'`.
     pub fn pad_matrix_to_ignore_garbage(
         &self,
         conv_shape_og: &[usize],


### PR DESCRIPTION
This PR pads the dense layer matrix such that output of the fft convolution matches the output of the unpadded school book convolution. 