### PR TITLE
Add the `clippy.toml` file

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 8

--- a/mpcs/src/basefold/commit_phase.rs
+++ b/mpcs/src/basefold/commit_phase.rs
@@ -175,7 +175,6 @@ where
 }
 
 // outputs (trees, sumcheck_oracles, oracles, bh_evals, eq, eval)
-#[allow(clippy::too_many_arguments)]
 pub fn batch_commit_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
     pp: &<Spec::EncodingScheme as EncodingScheme<E>>::ProverParameters,
     point: &[E],
@@ -345,7 +344,6 @@ where
 }
 
 // outputs (trees, sumcheck_oracles, oracles, bh_evals, eq, eval)
-#[allow(clippy::too_many_arguments)]
 pub fn simple_batch_commit_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
     pp: &<Spec::EncodingScheme as EncodingScheme<E>>::ProverParameters,
     point: &[E],

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-criterion.workspace = true
 ff.workspace = true
 goldilocks.workspace = true
 serde.workspace = true
@@ -18,6 +17,7 @@ unroll = "0.1"
 
 [dev-dependencies]
 ark-std.workspace = true
+criterion.workspace = true
 plonky2.workspace = true
 rand.workspace = true
 


### PR DESCRIPTION
Adds the `clippy.toml` file to allow fine-grained configuration of Clippy lints. For example, `disallowed-types` or `doc-valid-idents`.

This PR specifically raises the `too-many-arguments` threshold from 7 to 8, which allows the removal of some `#[allow(clippy::too_many_arguments)]` flags. There are functions with more than 8 parameters but they don't seem worth changing IMO.