### PR TITLE
chore: bump python3 msv for zkml

### DIFF
--- a/zkml/README.md
+++ b/zkml/README.md
@@ -52,7 +52,7 @@ ZKML is built on cryptographic techniques that allow for efficient proof generat
 
 To get started with ZKML, ensure you have the following prerequisites:
 
-- **Python 3.6 or higher**
+- **Python 3.10 or higher**
 - **Rust and Cargo** (latest stable)
 - **EZKL** (optional, for comparisons)
 


### PR DESCRIPTION
The `bench.py` file has a `match` expression, for which msv is 3.10: https://peps.python.org/pep-0622/