### PR TITLE
chore: allow more than one syn dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,6 @@ dependencies = [
  "plonky2",
  "rand",
  "serde",
- "unroll",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ thiserror = "2.0.12"
 tiny-keccak = "2.0"
 tracing-flame = "0.2.0"
 tract-onnx = "0.21.13"
-unroll = "0.1"
 
 # Test must run fast, but still provides stacktraces.
 [profile.test]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allowed-duplicate-crates = ["syn"]

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -13,7 +13,6 @@ version.workspace = true
 criterion.workspace = true
 ff_ext = { path = "../ff_ext" }
 serde.workspace = true
-unroll = { workspace = true }
 p3-challenger = { workspace = true }
 p3-field = { workspace = true }
 p3-goldilocks = { workspace = true }


### PR DESCRIPTION
both version `1` and `2` of the `syn` package are used through out. This is currently cumbersome to fix because the different versions are being pulled by dependencies, so just disable the lint for that crate (which is a macro anyways, so it should cause issues like the lint suggests)