### PR TITLE
chore: fix misspelling issues

### DIFF
--- a/zkml/src/layers/transformer/mha.rs
+++ b/zkml/src/layers/transformer/mha.rs
@@ -193,7 +193,7 @@ impl<N: Number> Evaluate<N> for MhaQK {
         // The next operation in transformer is softmax row by row, and then qk @ v, "row by row" - but
         // it's actually "head by head" which is the highest dimension.
         // So for the shapes, it's [q_len,seq_len] @ [seq_len, head_dim] = [q_len, head_dim]
-        // This is done in separate layer in the framework since we first need to prove softmax which happens separatedly
+        // This is done in separate layer in the framework since we first need to prove softmax which happens separately
         Ok(LayerOut::from_vec(vec![qk_infinitized, v]))
     }
 }
@@ -210,7 +210,7 @@ impl QuantizeOp for MhaQK {
     ) -> anyhow::Result<QuantizeOutput<Self::QuantizedOp>> {
         let num_outputs = self.num_outputs(input_scaling.len());
         // it will return a scaling factors for all heads merged together, but that's what we want since we don't want
-        // to have one requant layer _per head_ it would be too costly. So we take the min/max accross all the heads concatenated.
+        // to have one requant layer _per head_ it would be too costly. So we take the min/max across all the heads concatenated.
         let output_scalings = S::scaling_factors_for_node(data, node_id, num_outputs);
         ensure!(
             output_scalings.len() == 2,

--- a/zkml/src/layers/transformer/qkv.rs
+++ b/zkml/src/layers/transformer/qkv.rs
@@ -451,7 +451,7 @@ where
         );
         step_data.outputs.outputs().into_iter().try_for_each(|out| {
                 ensure!(out.get_shape() == expected_output_shape,
-                    "Expected shape {expected_output_shape:?} for output of QKV layer, foudn shape {:?}", out.get_shape(),
+                    "Expected shape {expected_output_shape:?} for output of QKV layer, found shape {:?}", out.get_shape(),
                 );
                 Ok(())
             }

--- a/zkml/src/model/llm.rs
+++ b/zkml/src/model/llm.rs
@@ -2,7 +2,7 @@
 //! and the output of the model. It can decide to re-run the model on a different input,
 //! to modify the inference trace, to modify the model, etc.
 //! The main usage of a driver for now is to run the LLM forward loop until a specific token or
-//! the maximum context length is reached. It will also be used to preprend a system model correctly.
+//! the maximum context length is reached. It will also be used to prepend a system model correctly.
 
 use serde::{Serialize, de::DeserializeOwned};
 use std::path::Path;


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspelling:
  - `separatedly` → `separately`
  - `accross` → `across`
  - `foudn` → `found`
  - `preprend` → `prepend`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.