### PR TITLE
perf: optimise get_perm

### DIFF
--- a/ff_ext/src/poseidon.rs
+++ b/ff_ext/src/poseidon.rs
@@ -1,4 +1,4 @@
-use p3_field::{FieldAlgebra, PrimeField};
+use p3_field::PrimeField;
 use p3_symmetric::CryptographicPermutation;
 
 use crate::SmallField;
@@ -6,14 +6,4 @@ use crate::SmallField;
 pub trait PoseidonField: PrimeField + SmallField {
     type T: CryptographicPermutation<[Self; 8]>;
     fn get_perm() -> Self::T;
-}
-
-pub(crate) fn new_array<const N: usize, F: FieldAlgebra>(input: [u64; N]) -> [F; N] {
-    let mut output = [F::ZERO; N];
-    let mut i = 0;
-    while i < N {
-        output[i] = F::from_canonical_u64(input[i]);
-        i += 1;
-    }
-    output
 }


### PR DESCRIPTION
This introduces a no alloc version of the poseidon2hl permutation, this results the following improvements:

- 50% witness context generation
- 25% proof generation

which results in a overall 21% speed of the proving time