### PR TITLE
build: use thin LTO for `release`, introduce `fast` with fat LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,13 +96,13 @@ overflow-checks = true
 opt-level = 3
 
 [profile.release]
-lto = "fat"
-
-[profile.release-with-debug]
-debug = true
+debug = 1
 debug-assertions = true
-inherits = "release"
 lto = "thin"
+
+[profile.fast]
+inherits = "release"
+lto = "fat"
 
 #[patch."https://github.com/nikkolasg/timed-rs"]
 #timed = { path = "/Users/nalos/prog/timed/timed" }


### PR DESCRIPTION
The `release` profile is now using thin LTO, and a new profile `fast` enabling fat LTO is introduced.

This slashes the compile times of the final binaries by nearly 70% on local machines, and is expected to greatly accelerate CI dockers build – note that the tests were already not using fat LTO, so no changes are expected there.