### PR TITLE
feat: take ownership of trace when converting to felt

### DIFF
--- a/deep-prove/src/bin/worker/main.rs
+++ b/deep-prove/src/bin/worker/main.rs
@@ -127,7 +127,7 @@ async fn run_model_v1(model: DeepProveRequestV1, mut store: impl Store) -> Resul
             let mut prover_transcript = default_transcript();
             let prover = Prover::<_, _, _>::new(&ctx, &mut prover_transcript);
             let proof = prover
-                .prove(&trace)
+                .prove(trace)
                 .with_context(|| "unable to generate proof for {i}th input")?;
 
             proofs.push(proof);

--- a/zkml/benches/prove-model.rs
+++ b/zkml/benches/prove-model.rs
@@ -58,13 +58,14 @@ fn run_model<T: std::io::Read>(model_data: &[u8], inputs: T) {
 
         let mut prover_transcript = new_transcript();
         let prover = Prover::<_, _, _>::new(ctx.as_ref().unwrap(), &mut prover_transcript);
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let io = trace.to_verifier_io();
+        let proof = prover.prove(trace).expect("unable to generate proof");
 
         let mut verifier_transcript = new_transcript();
         verify::<_, _, _>(
             ctx.as_ref().unwrap().clone(),
             proof,
-            trace.to_verifier_io(),
+            io,
             &mut verifier_transcript,
         )
         .expect("invalid proof");

--- a/zkml/src/bin/bench.rs
+++ b/zkml/src/bin/bench.rs
@@ -393,7 +393,7 @@ fn run(args: Args) -> anyhow::Result<()> {
         let io = trace.to_verifier_io();
         let mut prover_transcript = new_transcript();
         let prover = Prover::<_, _, _>::new(ctx.as_ref().unwrap(), &mut prover_transcript);
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
 
         // Serialize proof using MessagePack and calculate size in KB
         let proof_bytes = to_vec_named(&proof)?;

--- a/zkml/src/iop/mod.rs
+++ b/zkml/src/iop/mod.rs
@@ -117,7 +117,7 @@ mod test {
             Context::<F, Pcs<F>>::generate(&model, None, None).expect("unable to generate context");
         let mut prover_transcript = default_transcript();
         let prover = Prover::<_, _, _>::new(&ctx, &mut prover_transcript);
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
         let mut verifier_transcript = default_transcript();
         verify::<_, _, _>(ctx, proof, io, &mut verifier_transcript).expect("invalid proof");
     }
@@ -133,7 +133,7 @@ mod test {
             Context::<F, Pcs<F>>::generate(&model, None, None).expect("unable to generate context");
         let mut prover_transcript = default_transcript();
         let prover = Prover::<_, _, _>::new(&ctx, &mut prover_transcript);
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
         let mut verifier_transcript = default_transcript();
         verify::<_, _, _>(ctx, proof, io, &mut verifier_transcript).expect("invalid proof");
     }

--- a/zkml/src/iop/prover.rs
+++ b/zkml/src/iop/prover.rs
@@ -397,13 +397,13 @@ where
 
     pub fn prove<'b>(
         mut self,
-        full_trace: &InferenceTrace<'b, E, Element>,
+        full_trace: InferenceTrace<'b, E, Element>,
     ) -> anyhow::Result<Proof<E, PCS>> {
         debug!("== Instantiate witness context ==");
 
         let metrics = Metrics::new();
         self.ctx.write_to_transcript(self.transcript)?;
-        self.instantiate_witness_ctx(full_trace)?;
+        self.instantiate_witness_ctx(&full_trace)?;
 
         let span = metrics.to_span();
         stream_metrics("Witness context", &span);

--- a/zkml/src/lib.rs
+++ b/zkml/src/lib.rs
@@ -257,7 +257,7 @@ mod test {
         let mut prover_transcript = default_transcript();
         let prover = Prover::<_, _, _>::new(&ctx, &mut prover_transcript);
         println!("[+] Run prover");
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
 
         let mut verifier_transcript = default_transcript();
         verify::<_, _, _>(ctx, proof, io, &mut verifier_transcript).expect("invalid proof");

--- a/zkml/src/model/mod.rs
+++ b/zkml/src/model/mod.rs
@@ -1027,7 +1027,7 @@ pub(crate) mod test {
         let io = trace.to_verifier_io();
         let prover: Prover<'_, GoldilocksExt2, BasicTranscript<GoldilocksExt2>, _> =
             Prover::new(&ctx, &mut tr);
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
         let mut verifier_transcript: BasicTranscript<GoldilocksExt2> =
             BasicTranscript::new(b"m2vec");
         verify::<_, _, _>(ctx, proof, io, &mut verifier_transcript).unwrap();
@@ -1065,7 +1065,7 @@ pub(crate) mod test {
             Context::<F, Pcs<F>>::generate(&model, None, None).expect("Unable to generate context");
         let io = trace.to_verifier_io();
         let prover = Prover::new(&ctx, &mut tr);
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
         let mut verifier_transcript = BasicTranscript::<F>::new(b"matmul");
         verify::<_, _, _>(ctx, proof, io, &mut verifier_transcript).unwrap();
     }
@@ -1104,7 +1104,7 @@ pub(crate) mod test {
 
         let prover: Prover<'_, GoldilocksExt2, BasicTranscript<GoldilocksExt2>, _> =
             Prover::new(&ctx, &mut tr);
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
 
         let mut verifier_transcript: BasicTranscript<GoldilocksExt2> =
             BasicTranscript::new(b"m2vec");
@@ -1155,7 +1155,7 @@ pub(crate) mod test {
                         let io = trace.to_verifier_io();
                         let prover: Prover<'_, GoldilocksExt2, BasicTranscript<GoldilocksExt2>, _> =
                             Prover::new(&ctx, &mut tr);
-                        let proof = prover.prove(&trace).expect("unable to generate proof");
+                        let proof = prover.prove(trace).expect("unable to generate proof");
                         let mut verifier_transcript: BasicTranscript<GoldilocksExt2> =
                             BasicTranscript::new(b"m2vec");
                         verify::<_, _, _>(ctx, proof, io, &mut verifier_transcript).unwrap();
@@ -1275,7 +1275,7 @@ pub(crate) mod test {
             .expect("Unable to generate context");
         let prover: Prover<'_, E, T, _> = Prover::new(&ctx, &mut tr);
         let io = trace.to_verifier_io();
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
         let mut verifier_transcript: BasicTranscript<GoldilocksExt2> =
             BasicTranscript::new(b"model");
         verify::<_, _, _>(ctx, proof, io, &mut verifier_transcript)?;

--- a/zkml/src/model/trace.rs
+++ b/zkml/src/model/trace.rs
@@ -47,25 +47,25 @@ impl<'a, E: ExtensionField, N, D> Trace<'a, E, N, D> {
 
     /// Convert an inference trace computed over integers to a trace over field elements, which is
     /// needed to prove the inference
-    pub(crate) fn as_fields(&self) -> ProvingTrace<'a, E, N>
+    pub(crate) fn as_fields(self) -> ProvingTrace<'a, E, N>
     where
         D: Fieldizer<E>,
     {
-        let input = self.input.iter().map(|inp| inp.to_fields()).collect();
-        let output = self.output.iter().map(|out| out.to_fields()).collect();
+        let input = self.input.into_iter().map(|inp| inp.to_fields()).collect();
+        let output = self.output.into_iter().map(|out| out.to_fields()).collect();
         let field_steps = self
             .steps
-            .iter()
+            .into_iter()
             .map(|(id, step)| {
                 (
-                    *id,
+                    id,
                     InferenceStep {
                         op: step.op,
                         step_data: StepData {
                             inputs: step
                                 .step_data
                                 .inputs
-                                .iter()
+                                .into_iter()
                                 .map(|inp| inp.to_fields())
                                 .collect(),
                             outputs: LayerOut {
@@ -73,12 +73,12 @@ impl<'a, E: ExtensionField, N, D> Trace<'a, E, N, D> {
                                     .step_data
                                     .outputs
                                     .outputs
-                                    .iter()
+                                    .into_iter()
                                     .map(|out| out.to_fields())
                                     .collect(),
-                                proving_data: step.step_data.outputs.proving_data.clone(),
+                                proving_data: step.step_data.outputs.proving_data,
                             },
-                            unpadded_output_shapes: step.step_data.unpadded_output_shapes.clone(),
+                            unpadded_output_shapes: step.step_data.unpadded_output_shapes,
                         },
                     },
                 )

--- a/zkml/src/parser/mod.rs
+++ b/zkml/src/parser/mod.rs
@@ -583,7 +583,7 @@ mod tests {
         info!("GENERATING Proof...");
         let prover: Prover<'_, GoldilocksExt2, BasicTranscript<GoldilocksExt2>, _> =
             Prover::new(&ctx, &mut tr);
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
         info!("GENERATING Proof DONE...");
         let mut verifier_transcript: BasicTranscript<GoldilocksExt2> =
             BasicTranscript::new(b"m2vec");
@@ -629,7 +629,7 @@ mod tests {
         let prover: Prover<'_, GoldilocksExt2, BasicTranscript<GoldilocksExt2>, _> =
             Prover::new(&ctx, &mut tr);
         let io = trace.to_verifier_io();
-        let proof = prover.prove(&trace).expect("unable to generate proof");
+        let proof = prover.prove(trace).expect("unable to generate proof");
         let mut verifier_transcript: BasicTranscript<GoldilocksExt2> =
             BasicTranscript::new(b"m2vec");
         verify::<_, _, _>(ctx, proof, io, &mut verifier_transcript).unwrap();


### PR DESCRIPTION
This branch:
```
== Running model metrics: elapsed=49.203729208s peak=1.5 GiB in_use=1.5 GiB ==
== Checking accuracy metrics: elapsed=4.542µs peak=1.5 GiB in_use=1.5 GiB ==
== Witness poly fields generation metrics elapsed=38.930352083s peak=9.1 GiB in_use=9.1 GiB ==
== Witness table multiplicities metrics elapsed=32.021958ms peak=9.2 GiB in_use=9.2 GiB ==
== Challenge storage metrics elapsed=11.25µs peak=9.2 GiB in_use=9.2 GiB ==
== Witness context metrics elapsed=38.963433083s peak=9.2 GiB in_use=9.2 GiB ==
== Claims generation metrics elapsed=97.758545958s peak=13.8 GiB in_use=9.2 GiB ==
== Generate proof metrics elapsed=4.763347375s peak=11.0 GiB in_use=1.9 GiB ==
== Proving metrics: elapsed=141.569284458s peak=1.9 GiB in_use=378.5 MiB ==
```

[Previous tests](https://github.com/Lagrange-Labs/deep-prove/pull/223):
```
== Running model metrics: elapsed=42.242551917s peak=1.5 GiB in_use=1.5 GiB ==
== Checking accuracy metrics: elapsed=4.167µs peak=1.5 GiB in_use=1.5 GiB ==
== Witness poly fields generation metrics elapsed=34.701185459s peak=9.1 GiB in_use=9.1 GiB ==
== Witness table multiplicities metrics elapsed=46.575084ms peak=9.2 GiB in_use=9.2 GiB ==
== Challenge storage metrics elapsed=45.167µs peak=9.2 GiB in_use=9.2 GiB ==
== Witness context metrics elapsed=34.748281083s peak=9.2 GiB in_use=9.2 GiB ==
== Claims generation metrics elapsed=65.881611292s peak=14.9 GiB in_use=10.3 GiB ==
== Generate proof metrics elapsed=4.77605975s peak=12.2 GiB in_use=3.0 GiB ==
== Proving metrics: elapsed=105.490720375s peak=3.0 GiB in_use=1.5 GiB ==
== Verifier metrics: elapsed=2.129730083s peak=1.9 GiB in_use=1.5 GiB ==
```

Claim generation frees 1.1GiB