### PR TITLE
fix: remove another parallel iterator to ensure IEEE754 determinism

### DIFF
--- a/zkml/src/tensor.rs
+++ b/zkml/src/tensor.rs
@@ -1144,7 +1144,6 @@ where
                 let j = index % p;
 
                 *res = (0..n)
-                    .into_par_iter()
                     .map(|k| self.data[i * n + k] * other.data[k * p + j])
                     .sum::<T>();
             });


### PR DESCRIPTION
similar to #203 there was another nested par iter in tensor op that was causing non-deterministic results, as observed in e.g. `layers::transformer::mha::test::test_mha_with_real_values` where the mha-qk and requant layer would occasionally run with a slightly different input