### PR TITLE
perf: dont clone witness when proving

### DIFF
--- a/zkml/src/layers/activation.rs
+++ b/zkml/src/layers/activation.rs
@@ -395,19 +395,18 @@ impl<N> Activation<N> {
         E::BaseField: Serialize + DeserializeOwned,
     {
         // Should only be one prover_info for this step
-        let logup_witnesses = prover.lookup_witness(node_id)?;
-        if logup_witnesses.len() != 1 {
-            return Err(anyhow!(
-                "Activation only requires a lookup into one table type, but node: {} had {} lookup witnesses",
-                node_id,
-                logup_witnesses.len()
-            ));
-        }
-        let logup_witness = &logup_witnesses[0];
+        let mut logup_witnesses = prover.lookup_witness(node_id)?;
+        ensure!(
+            logup_witnesses.len() == 1,
+            "Activation only requires a lookup into one table type, but node: {} had {} lookup witnesses",
+            node_id,
+            logup_witnesses.len()
+        );
+        let logup_witness = logup_witnesses.pop().expect("Length was checked above");
         // Run the lookup protocol and return the lookup proof
         let prover_info = logup_witness.get_logup_input(&prover.challenge_storage)?;
 
-        let commits = logup_witness.get_commitments();
+        let commits = logup_witness.into_commitments();
         // Run the lookup protocol and return the lookup proof
         let logup_proof = logup_batch_prove(&prover_info, prover.transcript)?;
 

--- a/zkml/src/layers/pooling.rs
+++ b/zkml/src/layers/pooling.rs
@@ -363,18 +363,17 @@ impl Pooling {
     {
         assert_eq!(input.get_shape().len(), 3, "Maxpool needs 3D inputs.");
         // Should only be one prover_info for this step
-        let logup_witnesses = prover.lookup_witness(id)?;
-        if logup_witnesses.len() != 1 {
-            return Err(anyhow!(
-                "Pooling only requires a lookup into one table type, but node: {} had {} lookup witnesses",
-                id,
-                logup_witnesses.len()
-            ));
-        }
-        let logup_witness = &logup_witnesses[0];
+        let mut logup_witnesses = prover.lookup_witness(id)?;
+        ensure!(
+            logup_witnesses.len() == 1,
+            "Pooling only requires a lookup into one table type, but node: {} had {} lookup witnesses",
+            id,
+            logup_witnesses.len(),
+        );
+        let logup_witness = logup_witnesses.pop().expect("Length is checked above");
 
         let prover_info = logup_witness.get_logup_input(&prover.challenge_storage)?;
-        let commits = logup_witness.get_commitments();
+        let commits = logup_witness.into_commitments();
         let logup_proof = logup_batch_prove(&prover_info, prover.transcript)?;
 
         // These are the polys that get passed to the zero check make sure their product is zero at every evaluation point

--- a/zkml/src/layers/transformer/layernorm.rs
+++ b/zkml/src/layers/transformer/layernorm.rs
@@ -816,10 +816,10 @@ impl LayerNorm<Element> {
 
         // Run the lookup protocol and return the lookup proof
         let (commits, logup_proofs): CommsAndProofs<PCS, E> = logup_witnesses
-            .iter()
+            .into_iter()
             .map(|logup_wit| {
-                let commits = logup_wit.get_commitments();
                 let logup_input = logup_wit.get_logup_input(&prover.challenge_storage)?;
+                let commits = logup_wit.into_commitments();
                 let logup_proof = batch_prove(&logup_input, prover.transcript)?;
                 Ok((commits, logup_proof))
             })

--- a/zkml/src/layers/transformer/logits.rs
+++ b/zkml/src/layers/transformer/logits.rs
@@ -343,7 +343,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ProvableOp<E, PCS> f
 
         let max_values = &argmax_data.max_values[0];
 
-        let logup_witnesses = prover.lookup_witness(node_id)?;
+        let mut logup_witnesses = prover.lookup_witness(node_id)?;
 
         ensure!(
             logup_witnesses.len() == 1,
@@ -351,11 +351,11 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ProvableOp<E, PCS> f
             logup_witnesses.len(),
         );
 
-        let logup_witness = &logup_witnesses[0];
+        let logup_witness = logup_witnesses.pop().expect("Length is checked above");
 
         let logup_input = logup_witness.get_logup_input(&prover.challenge_storage)?;
 
-        let mut commits = logup_witness.get_commitments();
+        let mut commits = logup_witness.into_commitments();
 
         ensure!(
             commits.len() == 1,

--- a/zkml/src/layers/transformer/softmax.rs
+++ b/zkml/src/layers/transformer/softmax.rs
@@ -607,10 +607,10 @@ impl Softmax<Element> {
         }
         // Run the lookup protocol and return the lookup proof
         let (commits, logup_proofs): CommsAndProofs<PCS, E> = logup_witnesses
-            .iter()
+            .into_iter()
             .map(|logup_wit| {
-                let commits = logup_wit.get_commitments();
                 let logup_input = logup_wit.get_logup_input(&prover.challenge_storage)?;
+                let commits = logup_wit.into_commitments();
                 let logup_proof = batch_prove(&logup_input, prover.transcript)?;
                 Ok((commits, logup_proof))
             })

--- a/zkml/src/lookup/witness.rs
+++ b/zkml/src/lookup/witness.rs
@@ -153,4 +153,15 @@ where
             } => vec![multiplicity_commit.clone()],
         }
     }
+
+    /// Consumes the witness and returns its commitments.
+    pub fn into_commitments(self) -> Vec<ProverCommitment<PCS, E>> {
+        match self {
+            LogUpWitness::Lookup { commits, .. } => commits,
+            LogUpWitness::Table {
+                multiplicity_commit,
+                ..
+            } => vec![multiplicity_commit],
+        }
+    }
 }


### PR DESCRIPTION
master:
```
== Running model metrics: elapsed=60.449222458s peak=1.5 GiB in_use=1.5 GiB ==
== Checking accuracy metrics: elapsed=4.625µs peak=1.5 GiB in_use=1.5 GiB ==
== Witness poly fields generation metrics elapsed=45.727657791s peak=9.1 GiB in_use=9.1 GiB ==
== Witness table multiplicities metrics elapsed=392.636875ms peak=9.2 GiB in_use=9.2 GiB ==
== Challenge storage metrics elapsed=17.625µs peak=9.2 GiB in_use=9.2 GiB ==
== Witness context metrics elapsed=46.121288792s peak=9.2 GiB in_use=9.2 GiB ==
== Claims generation metrics elapsed=88.943723208s peak=13.9 GiB in_use=9.3 GiB ==
== Generate proof metrics elapsed=6.155216709s peak=11.2 GiB in_use=1.9 GiB ==
== Proving metrics: elapsed=141.3274805s peak=1.9 GiB in_use=378.7 MiB ==
```
this branch:
```
== Running model metrics: elapsed=44.844812417s peak=1.5 GiB in_use=1.5 GiB ==
== Checking accuracy metrics: elapsed=4.333µs peak=1.5 GiB in_use=1.5 GiB ==
== Witness poly fields generation metrics elapsed=50.1269505s peak=9.1 GiB in_use=9.1 GiB ==
== Witness table multiplicities metrics elapsed=455.876083ms peak=9.2 GiB in_use=9.2 GiB ==
== Challenge storage metrics elapsed=20.625µs peak=9.2 GiB in_use=9.2 GiB ==
== Witness context metrics elapsed=50.583881917s peak=9.2 GiB in_use=9.2 GiB ==
== Claims generation metrics elapsed=84.513571916s peak=11.3 GiB in_use=9.3 GiB ==
== Generate proof metrics elapsed=7.525828083s peak=11.2 GiB in_use=1.9 GiB ==
== Proving metrics: elapsed=142.729508125s peak=1.9 GiB in_use=378.7 MiB ==
```

It saves 2.6GiB when proving the claims.