### PR TITLE
docs: fix typos in dense and end-to-end LU documentation

### DIFF
--- a/docs/src/dense.md
+++ b/docs/src/dense.md
@@ -48,7 +48,7 @@ This equation can be proven via a sumcheck !
 
 The output of the sumcheck is a proof and a new claim on both $\tilde{W}(r,...)$ and $\tilde{x}(...)$. The proof is only valid if the verifier can verify those claims are too!
 * Matrix claim: the matrix claim gets accumulated with our accumulation scheme setup at the beginning of the proving phase. At the end of the full flow, the accumulation procedure will output a single randomized claim from which the prover will produce a PCS opening proof. In short, we delay the verification of the claim to the end.
-* Input claim: this claims now becomes the *input* claim for the previous layer in the model ! Remember deeo prove proves backwards, from the last to the first layer.
+* Input claim: this claims now becomes the *input* claim for the previous layer in the model ! Remember deep prove proves backwards, from the last to the first layer.
 
 ### 2. Bias Addition Proof
 

--- a/docs/src/end_to_end_lu.md
+++ b/docs/src/end_to_end_lu.md
@@ -1,5 +1,5 @@
 # End-to-End Lookup Protocol
-Since a model will have many repeated layers to improve efficiency we aim to only produce one multiplicity polynomial per table type. An added bonus to this is that at each step we only have to do proving work proportional to the number of lookups (for lookup steps) or the table size (for mulitpilcity polynomials).
+Since a model will have many repeated layers to improve efficiency we aim to only produce one multiplicity polynomial per table type. An added bonus to this is that at each step we only have to do proving work proportional to the number of lookups (for lookup steps) or the table size (for multiplicity polynomials).
 
 ## Splitting Lookups and Tables
 As a quick recap the LogUp protocol works as follows. If we have a table $` T:=\{t_{i} \}_{i = 1}^{m} `$ and a set of values $` L:= \{lk_{i}\}_{i=1}^{n} `$ to be looked up then the LogUp protocol proves 


### PR DESCRIPTION
- Corrected "deeo prove" → "deep prove" in `dense.md`
- Fixed "mulitpilcity" → "multiplicity" in `end_to_end_lu.md`