### PR TITLE
Support Conv2D with non-zero spatial padding

### DIFF
--- a/zkml/src/iop/prover.rs
+++ b/zkml/src/iop/prover.rs
@@ -108,7 +108,7 @@ where
 
     #[timed::timed_instrument(level = "debug")]
     fn prove_tables(&mut self) -> anyhow::Result<()> {
-        let mut table_witness = std::mem::replace(&mut self.table_witness, Vec::new());
+        let mut table_witness = std::mem::take(&mut self.table_witness);
         table_witness.reverse();
 
         while let Some(table_witness) = table_witness.pop() {

--- a/zkml/src/layers/convolution.rs
+++ b/zkml/src/layers/convolution.rs
@@ -57,6 +57,11 @@ pub struct Convolution<T> {
     pub bias: Tensor<T>,
     /// Unpadded shape of the filter. This is set to filter's shape in case of no padding.
     pub unpadded_shape: Shape,
+    /// Spatial zero-padding applied to H and W dimensions of the input before convolution.
+    /// Equivalent to ONNX `pads` = [pad_h, pad_w, pad_h, pad_w].
+    /// Default is [0, 0] (valid / no-padding convolution).
+    #[serde(default)]
+    pub input_padding: [usize; 2],
 }
 
 /// Info about the convolution layer derived during the setup phase
@@ -77,6 +82,9 @@ pub struct ConvCtx<E> {
     pub filter_size: usize,
     pub unpadded_filter_shape: Shape,
     pub padded_filter_shape: Shape,
+    /// Spatial zero-padding applied to input before convolution; mirrors `Convolution::input_padding`.
+    #[serde(default)]
+    pub input_padding: [usize; 2],
 }
 
 pub fn to_bits<E: ExtensionField>(mut num: usize, bitlen: usize) -> Vec<E> {
@@ -128,6 +136,18 @@ impl<T: Number> Convolution<T> {
         Self::new_padded(filter, bias, &filter_shape)
     }
 
+    pub fn new_with_padding(filter: Tensor<T>, bias: Tensor<T>, input_padding: [usize; 2]) -> Self {
+        assert_eq!(filter.kw(), bias.get_shape()[0]);
+        assert_eq!(filter.get_shape().len(), 4);
+        let filter_shape = filter.get_shape();
+        Self {
+            filter,
+            bias,
+            unpadded_shape: filter_shape,
+            input_padding,
+        }
+    }
+
     pub(crate) fn new_without_bias(filter: Tensor<T>) -> Self {
         let bias = Tensor::zeros(Shape::new(vec![filter.kw()]));
         Self::new(filter, bias)
@@ -139,13 +159,19 @@ impl<T: Number> Convolution<T> {
             filter,
             bias,
             unpadded_shape: unpadded_shape.clone(),
+            input_padding: [0, 0],
         }
     }
     pub fn output_shape(&self, input_shape: &Shape, padding_mode: PaddingMode) -> Shape {
+        let [ph, pw] = self.input_padding;
         match padding_mode {
             // unpadded shape is the shape found in onxx file for example
-            PaddingMode::NoPadding => conv2d_shape(input_shape, &self.unpadded_shape),
-            PaddingMode::Padding => padded_conv2d_shape(input_shape, &self.filter.real_shape()),
+            PaddingMode::NoPadding => {
+                conv2d_shape_with_padding(input_shape, &self.unpadded_shape, ph, pw)
+            }
+            PaddingMode::Padding => {
+                padded_conv2d_shape_with_padding(input_shape, &self.filter.real_shape(), ph, pw)
+            }
         }
     }
 
@@ -245,7 +271,9 @@ impl Evaluate<f32> for Convolution<f32> {
             "Found more than 1 input when evaluating convolution layer"
         );
         let input = inputs[0];
-        Ok(LayerOut::from_vec(vec![input.conv2d(
+        let [ph, pw] = self.input_padding;
+        let padded = input.zero_pad_spatial(ph, pw);
+        Ok(LayerOut::from_vec(vec![padded.conv2d(
             &self.filter,
             &self.bias,
             1,
@@ -260,11 +288,15 @@ impl Convolution<f32> {
     pub fn quantize(self, s: &ScalingFactor, bias_s: &ScalingFactor) -> Convolution<Element> {
         let quantized_filter = self.filter.quantize(s);
         let bias = self.bias.quantize(bias_s);
-        Convolution::<Element>::new(quantized_filter, bias)
+        let mut q = Convolution::<Element>::new(quantized_filter, bias);
+        q.input_padding = self.input_padding;
+        q
     }
 
     pub fn op<E: ExtensionField>(&self, input: &Tensor<f32>) -> Tensor<f32> {
-        input.conv2d(&self.filter, &self.bias, 1)
+        let [ph, pw] = self.input_padding;
+        let padded = input.zero_pad_spatial(ph, pw);
+        padded.conv2d(&self.filter, &self.bias, 1)
     }
 
     pub fn max_abs_weight(&self) -> f32 {
@@ -305,11 +337,34 @@ impl Evaluate<Element> for Convolution<Element> {
 }
 
 impl Convolution<Element> {
+    /// Returns the effective input shape after applying `input_padding` to the spatial dims.
+    ///
+    /// The FFT-based convolution operates on the spatially-padded input, so we compute
+    /// the filter's FFT with respect to this larger shape.
+    pub fn effective_input_shape(&self, unpadded_input_shape: &Shape) -> Shape {
+        let [ph, pw] = self.input_padding;
+        if ph == 0 && pw == 0 {
+            return unpadded_input_shape.clone();
+        }
+        // unpadded_input_shape is [C, H, W]
+        assert_eq!(
+            unpadded_input_shape.len(),
+            3,
+            "expected 3-D input shape [C,H,W]"
+        );
+        let c = unpadded_input_shape[0];
+        let h = unpadded_input_shape[1];
+        let w = unpadded_input_shape[2];
+        Shape::new(vec![c, h + 2 * ph, w + 2 * pw])
+    }
+
     /// Pads the filter and bias, and adapt the filter to the convolution fft operation.
     pub fn into_padded_and_ffted(mut self, unpadded_input_shape: &Shape) -> Self {
         self.filter = self.filter.pad_next_power_of_two();
         self.bias = self.bias.pad_next_power_of_two();
-        let padded_input_shape = unpadded_input_shape
+        // Use the spatially-padded input shape so the FFT is sized correctly.
+        let effective_shape = self.effective_input_shape(unpadded_input_shape);
+        let padded_input_shape = effective_shape
             .iter()
             .map(|&x| x.next_power_of_two())
             .collect::<Shape>();
@@ -322,16 +377,32 @@ impl Convolution<Element> {
         input: &Tensor<Element>,
         unpadded_input_shape: &Shape,
     ) -> (Tensor<Element>, ConvData<E>) {
-        let (output, mut proving_data) = self.filter.fft_conv(input);
+        // `input` is POT-padded. When there is ONNX spatial zero-padding we must:
+        //   1. Crop back to unpadded_input_shape (remove POT padding)
+        //   2. Apply ONNX spatial zero-padding
+        //   3. Re-apply POT padding for the FFT
+        // When there is no ONNX padding the input is used as-is.
+        let [ph, pw] = self.input_padding;
+        let fft_input: Tensor<Element> = if ph == 0 && pw == 0 {
+            input.clone()
+        } else {
+            // Crop `input` to the unpadded shape, then zero-pad spatially, then POT-pad.
+            // `unpadded_input_shape` is [C, H, W] (3-D).
+            let unpadded = input.crop_to(unpadded_input_shape);
+            let spatially = unpadded.zero_pad_spatial(ph, pw);
+            spatially.pad_next_power_of_two()
+        };
+        let (output, mut proving_data) = self.filter.fft_conv(&fft_input);
         let conv_output = self.add_bias(&output);
         // we record here the output _after_ the bias addition. During proving it's necessary since we're proving the clearing garbage
         // and that produces a new claim on this output.
         proving_data.set_output(conv_output.get_data());
         // At this stage, we're creating a "garbage clearing" tensor that sets all garbage values to 0. This is necessary
         // since the garbage might be of any value and we need to restrict the range of the output due to requantization proving logic.
-        let unpadded_output_shape = conv2d_shape(unpadded_input_shape, &self.unpadded_shape);
+        let effective_unpadded_input = self.effective_input_shape(unpadded_input_shape);
+        let unpadded_output_shape = conv2d_shape(&effective_unpadded_input, &self.unpadded_shape);
         debug_assert_eq!(
-            { padded_conv2d_shape(&input.get_shape(), &self.filter.real_shape()) },
+            { padded_conv2d_shape(&fft_input.get_shape(), &self.filter.real_shape(),) },
             conv_output.get_shape(),
             "FFT output shape not computable"
         );
@@ -528,6 +599,7 @@ where
             filter_size: self.filter_size(),
             unpadded_filter_shape: self.unpadded_shape.clone(),
             padded_filter_shape: self.filter.real_shape(),
+            input_padding: self.input_padding,
         });
 
         let filter_poly = self.filter.pad_next_power_of_two().get_data().to_vec();
@@ -1082,9 +1154,14 @@ where
     E: ExtensionField + Serialize + DeserializeOwned,
 {
     pub fn output_shape(&self, input_shape: &Shape, padding_mode: PaddingMode) -> Shape {
+        let [ph, pw] = self.input_padding;
         match padding_mode {
-            PaddingMode::NoPadding => conv2d_shape(input_shape, &self.unpadded_filter_shape),
-            PaddingMode::Padding => padded_conv2d_shape(input_shape, &self.padded_filter_shape),
+            PaddingMode::NoPadding => {
+                conv2d_shape_with_padding(input_shape, &self.unpadded_filter_shape, ph, pw)
+            }
+            PaddingMode::Padding => {
+                padded_conv2d_shape_with_padding(input_shape, &self.padded_filter_shape, ph, pw)
+            }
         }
     }
     pub(crate) fn verify_fft_delegation<T: Transcript<E>, PCS: PolynomialCommitmentScheme<E>>(
@@ -1163,12 +1240,20 @@ where
         // OR find a closed formula
         //
         // To recreat it, we need the unpadded output shape and the real output shape.
-        let unpadded_output_shape = conv2d_shape(
+        // Account for ONNX spatial padding: the effective input is spatially larger.
+        let [ph, pw] = self.input_padding;
+        let unpadded_output_shape = conv2d_shape_with_padding(
             &shape_step.unpadded_input_shape[0],
             &self.unpadded_filter_shape,
+            ph,
+            pw,
         );
-        let real_output_shape =
-            padded_conv2d_shape(&shape_step.padded_input_shape[0], &self.padded_filter_shape);
+        let real_output_shape = padded_conv2d_shape_with_padding(
+            &shape_step.padded_input_shape[0],
+            &self.padded_filter_shape,
+            ph,
+            pw,
+        );
         let clearing_tensor = new_clearing_tensor(&unpadded_output_shape, &real_output_shape);
         // now we need to verify the hadamard proof for the sumcheck part.
         let hctx = hadamard::HadamardCtx::from_len(real_output_shape.product());
@@ -1402,7 +1487,9 @@ impl<T: Number> Evaluate<T> for SchoolBookConv<T> {
             "Found more than 1 input when evaluating schoolbook convolution layer"
         );
         let input = inputs[0];
-        Ok(LayerOut::from_vec(vec![input.conv2d(
+        let [ph, pw] = self.0.input_padding;
+        let padded = input.zero_pad_spatial(ph, pw);
+        Ok(LayerOut::from_vec(vec![padded.conv2d(
             &self.0.filter,
             &self.0.bias,
             1,
@@ -1580,6 +1667,50 @@ pub fn conv2d_shape(input_shape: &Shape, filter_shape: &Shape) -> Shape {
 /// Similar to conv2d_shape but pads the output shape such that it matches what the padded inference and proving expects
 pub fn padded_conv2d_shape(input_shape: &Shape, filter_shape: &Shape) -> Shape {
     conv2d_shape(input_shape, filter_shape)
+        .into_vec()
+        .into_iter()
+        .map(|x| x.next_power_of_two())
+        .collect::<Shape>()
+}
+
+/// Like `conv2d_shape` but accounts for ONNX-style spatial zero-padding applied to the input.
+///
+/// The effective input spatial size is `(H + 2*pad_h) × (W + 2*pad_w)`, so the output is:
+/// `out = (spatial + 2*pad - kernel) / stride + 1` with stride=1.
+pub fn conv2d_shape_with_padding(
+    input_shape: &Shape,
+    filter_shape: &Shape,
+    pad_h: usize,
+    pad_w: usize,
+) -> Shape {
+    if pad_h == 0 && pad_w == 0 {
+        return conv2d_shape(input_shape, filter_shape);
+    }
+    let h_in = if input_shape.len() == 3 {
+        input_shape[1]
+    } else {
+        input_shape[2]
+    };
+    let w_in = if input_shape.len() == 3 {
+        input_shape[2]
+    } else {
+        input_shape[3]
+    };
+    let kh = filter_shape[2];
+    let kw = filter_shape[3];
+    let h_out = h_in + 2 * pad_h - kh + 1;
+    let w_out = w_in + 2 * pad_w - kw + 1;
+    Shape::new(vec![filter_shape[0], h_out, w_out])
+}
+
+/// Power-of-two padded variant of `conv2d_shape_with_padding`.
+pub fn padded_conv2d_shape_with_padding(
+    input_shape: &Shape,
+    filter_shape: &Shape,
+    pad_h: usize,
+    pad_w: usize,
+) -> Shape {
+    conv2d_shape_with_padding(input_shape, filter_shape, pad_h, pad_w)
         .into_vec()
         .into_iter()
         .map(|x| x.next_power_of_two())
@@ -1936,5 +2067,108 @@ mod test {
             fft_dense_output.get_data()[..weight.nrows_2d()]
         );
         Ok(())
+    }
+
+    /// Test that a Convolution with input_padding=[1,1] (ONNX "same" padding for kernel=3)
+    /// produces an output that matches naive zero-padding + conv2d, and that output spatial
+    /// dims equal input spatial dims ("same" convolution invariant).
+    #[test]
+    fn test_conv_with_padding() {
+        // Input: 1 channel, 8x8 spatial — padded to effective 10x10 with pad=1 on each side
+        let input_shape: Shape = vec![1, 8, 8].into();
+        let filter_shape: Shape = vec![4, 1, 3, 3].into(); // 4 out-channels, kernel=3
+
+        let filter: Tensor<f32> = Tensor::random(&filter_shape);
+        let bias: Tensor<f32> = Tensor::zeros(vec![filter_shape[0]].into());
+        let input: Tensor<f32> = Tensor::random(&input_shape);
+
+        // --- f32 path: Convolution::new_with_padding ---
+        let conv = Convolution::new_with_padding(filter.clone(), bias.clone(), [1, 1]);
+        let padded_input_naive = input.zero_pad_spatial(1, 1);
+        let expected_output = padded_input_naive.conv2d(&filter, &bias, 1);
+
+        let actual_output: Tensor<f32> = conv.op::<GoldilocksExt2>(&input);
+
+        assert_eq!(
+            actual_output.get_shape(),
+            expected_output.get_shape(),
+            "output shapes must match"
+        );
+        let actual_data = actual_output.get_data();
+        let expected_data = expected_output.get_data();
+        for (i, (a, e)) in actual_data.iter().zip(expected_data.iter()).enumerate() {
+            assert!(
+                (a - e).abs() < 1e-4,
+                "mismatch at index {}: actual={}, expected={}",
+                i,
+                a,
+                e
+            );
+        }
+
+        // "same" invariant: output H == input H, output W == input W
+        // output_shape returns [C_out, H_out, W_out]
+        let out_shape = actual_output.get_shape();
+        // remove batch dim if present
+        let spatial_h = if out_shape.len() == 4 {
+            out_shape[2]
+        } else {
+            out_shape[1]
+        };
+        let spatial_w = if out_shape.len() == 4 {
+            out_shape[3]
+        } else {
+            out_shape[2]
+        };
+        assert_eq!(spatial_h, 8, "output H must equal input H for same-conv");
+        assert_eq!(spatial_w, 8, "output W must equal input W for same-conv");
+    }
+
+    /// Test the Element (quantised / ZK) path for padding=1 convolution.
+    /// Verifies the FFT-based convolution with input_padding produces correct valid values.
+    #[test]
+    fn test_conv_with_padding_element() {
+        // Small input to keep FFT test fast
+        let input_shape: Shape = vec![1, 6, 6].into();
+        let filter_shape: Shape = vec![2, 1, 3, 3].into(); // 2 out-channels, kernel=3
+
+        let filter: Tensor<Element> = Tensor::random(&filter_shape);
+        let bias: Tensor<Element> = Tensor::zeros(vec![filter_shape[0]].into());
+        let input: Tensor<Element> = Tensor::random(&input_shape);
+
+        // Build the padded+ffted convolution with input_padding=[1,1]
+        let conv = Convolution::new_with_padding(filter.clone(), bias.clone(), [1, 1]);
+        let fft_conv = conv.into_padded_and_ffted(&input_shape);
+
+        // Run the FFT conv op
+        let padded_input = input.pad_next_power_of_two();
+        let (fft_output, _conv_data) = fft_conv.op::<GoldilocksExt2>(&padded_input, &input_shape);
+
+        // Naive reference: zero-pad input then conv2d
+        let padded_input_naive = input.zero_pad_spatial(1, 1);
+        let expected_output = padded_input_naive.conv2d(&filter, &bias, 1);
+        let expected_shape = expected_output.get_shape();
+
+        // Extract valid region from FFT output (ignoring power-of-two garbage)
+        let (valid, _garbage) = split_garbage(&fft_output, &expected_shape);
+        assert_eq!(
+            valid,
+            expected_output.get_data().to_vec(),
+            "FFT conv with input_padding=[1,1] must match naive zero-pad + conv2d"
+        );
+
+        // "same" invariant
+        let out_h = if expected_shape.len() == 4 {
+            expected_shape[2]
+        } else {
+            expected_shape[1]
+        };
+        let out_w = if expected_shape.len() == 4 {
+            expected_shape[3]
+        } else {
+            expected_shape[2]
+        };
+        assert_eq!(out_h, 6, "output H must equal input H for same-conv");
+        assert_eq!(out_w, 6, "output W must equal input W for same-conv");
     }
 }

--- a/zkml/src/padding.rs
+++ b/zkml/src/padding.rs
@@ -214,7 +214,6 @@ pub(crate) fn pad_conv(
         "More than 1 input shape found when padding convolution layer"
     );
     let sd = si.shapes.first_mut().unwrap();
-    sd.input_shape_og = safe_conv2d_shape(&sd.input_shape_og, &c.filter.get_shape())?;
     let weight_shape = c.filter.get_shape();
     // Perform basic sanity checks on the tensor dimensions
     check_filter(&weight_shape).context("filter shape test failed:")?;
@@ -231,11 +230,35 @@ pub(crate) fn pad_conv(
         sd.input_shape_padded.rank() == 3,
         "Input shape for convolution is not 3D"
     );
+
+    // Compute the effective input shapes after applying ONNX spatial zero-padding.
+    // When input_padding = [ph, pw], each spatial dimension grows by 2*ph / 2*pw.
+    let [ph, pw] = c.input_padding;
+    let effective_og = if ph > 0 || pw > 0 {
+        let orig = &sd.input_shape_og;
+        assert_eq!(orig.len(), 3, "expected 3-D input shape [C,H,W]");
+        Shape::new(vec![orig[0], orig[1] + 2 * ph, orig[2] + 2 * pw])
+    } else {
+        sd.input_shape_og.clone()
+    };
+    let effective_padded = if ph > 0 || pw > 0 {
+        // The power-of-two padded version of the effective (spatially-padded) input.
+        effective_og
+            .iter()
+            .map(|&x| x.next_power_of_two())
+            .collect::<Shape>()
+    } else {
+        sd.input_shape_padded.clone()
+    };
+
+    // Update output shapes using the effective (spatially-padded) input shapes.
+    sd.input_shape_og = safe_conv2d_shape(&effective_og, &c.filter.get_shape())?;
+
     let new_conv_good = c.clone();
     // Since we are doing an FFT based conv, we need to pad the last two dimensions of the filter to match the input.
     let weight_shape = c.filter.pad_next_power_of_two().get_shape();
     let (filter_height, filter_width) = (weight_shape[2], weight_shape[3]);
-    let (input_height, input_width) = (sd.input_shape_padded.dim(1), sd.input_shape_padded.dim(2));
+    let (input_height, input_width) = (effective_padded.dim(1), effective_padded.dim(2));
 
     ensure!(
         filter_height <= input_height && filter_width <= input_width,
@@ -243,7 +266,7 @@ pub(crate) fn pad_conv(
     );
 
     let new_conv = new_conv_good.into_padded_and_ffted(&sd.input_shape_og);
-    let output_shape: Shape = safe_conv2d_shape(&sd.input_shape_padded, &weight_shape)?;
+    let output_shape: Shape = safe_conv2d_shape(&effective_padded, &weight_shape)?;
     sd.input_shape_padded = output_shape.next_power_of_two();
     Ok(new_conv)
 }

--- a/zkml/src/parser/onnx.rs
+++ b/zkml/src/parser/onnx.rs
@@ -587,8 +587,7 @@ fn load_conv<'a, I: Iterator<Item = &'a usize> + Sized>(
     _iter: &mut Peekable<I>,
 ) -> Result<(NodeId, CustomNode)> {
     let conv_node = downcast_to::<Conv>(node)?;
-    // TODO: once we support different padding and strides, extract the data in this function
-    check_conv2d_attributes(conv_node)?;
+    let input_padding = check_conv2d_attributes(conv_node)?;
     // TODO: support for conv without bias
     ensure_onnx!(
         node.inputs.len() == 3,
@@ -605,9 +604,11 @@ fn load_conv<'a, I: Iterator<Item = &'a usize> + Sized>(
     let bias_const = extract_const_tensor(bias_node)?;
     let conv = if bias_const.is_empty() {
         // it's a convolution layer without bias
-        Convolution::new_without_bias(filter_const)
+        let mut c = Convolution::new_without_bias(filter_const);
+        c.input_padding = input_padding;
+        c
     } else {
-        Convolution::new(filter_const, bias_const)
+        Convolution::new_with_padding(filter_const, bias_const, input_padding)
     };
     let provable_node = crate::layers::provable::Node::new(
         vec![Edge::new(input_link.node, input_link.slot)],
@@ -644,28 +645,49 @@ fn get_node_output_shape(node: &OnnxNode, output_idx: usize) -> Result<Shape> {
     Ok(shape.to_vec().into())
 }
 
-/// Get the conv2d attributes and assert if supported by DeepProve
-fn check_conv2d_attributes(node: &Conv) -> Result<()> {
+/// Get the conv2d attributes and assert if supported by DeepProve.
+/// Returns the spatial input padding `[pad_h, pad_w]` extracted from ONNX `pads`.
+///
+/// Supported: symmetric padding (pad_begin == pad_end) with equal H and W pads.
+fn check_conv2d_attributes(node: &Conv) -> Result<[usize; 2]> {
     let Some(ref strides) = node.pool_spec.strides else {
         return err(format!("Conv has no strides: {}", node.name()));
     };
     ensure_onnx!(strides.iter().all(|&x| x == 1), "Strides must be {}", 1);
-    ensure_onnx!(strides.iter().all(|&x| x == 1), "Strides must be {}", 1);
-    let PaddingSpec::Explicit(ref pad0, ref pad1) = &node.pool_spec.padding else {
-        return err(format!("Conv has no pads: {}", node.name()));
+    let input_padding = match &node.pool_spec.padding {
+        PaddingSpec::Explicit(pad0, pad1) => {
+            // pad0 = begin pads [pad_h, pad_w], pad1 = end pads [pad_h, pad_w]
+            ensure_onnx!(
+                pad0.len() == 2 && pad1.len() == 2,
+                "Conv {} padding must be 2-D (H and W): pad0={:?} pad1={:?}",
+                node.name(),
+                pad0,
+                pad1,
+            );
+            ensure_onnx!(
+                pad0[0] == pad1[0] && pad0[1] == pad1[1],
+                "Conv {} padding must be symmetric (begin == end): pad0={:?} pad1={:?}",
+                node.name(),
+                pad0,
+                pad1,
+            );
+            ensure_onnx!(
+                pad0[0] == pad0[1],
+                "Conv {} padding must be equal on H and W: pad0={:?}",
+                node.name(),
+                pad0,
+            );
+            [pad0[0], pad0[1]]
+        }
+        PaddingSpec::Valid => [0, 0],
+        other => {
+            return err(format!(
+                "Conv {} has unsupported padding spec: {:?}",
+                node.name(),
+                other
+            ));
+        }
     };
-    ensure_onnx!(
-        pad0.iter().all(|&x| x == 0),
-        "Padding for {}must be 0s: {:?}",
-        node.name(),
-        pad0,
-    );
-    ensure_onnx!(
-        pad1.iter().all(|&x| x == 0),
-        "Padding for {}must be 0s: {:?}",
-        node.name(),
-        pad1,
-    );
     let Some(ref dilations) = node.pool_spec.dilations else {
         return err(format!("Conv has no dilations: {}", node.name()));
     };
@@ -694,7 +716,7 @@ fn check_conv2d_attributes(node: &Conv) -> Result<()> {
         node.name(),
         kernel_shape
     );
-    Ok(())
+    Ok(input_padding)
 }
 
 fn err<T>(msg: String) -> Result<T> {

--- a/zkml/src/tensor.rs
+++ b/zkml/src/tensor.rs
@@ -992,6 +992,84 @@ where
         self
     }
 
+    /// Zero-pad the spatial (H, W) dimensions of a [N, C, H, W] or [C, H, W] tensor.
+    ///
+    /// Each spatial dimension is padded by `pad_h` rows/columns on each side (top/bottom)
+    /// and `pad_w` columns on each side (left/right), producing a tensor whose spatial
+    /// dimensions are `(H + 2*pad_h) × (W + 2*pad_w)`.
+    ///
+    /// This is the "same" padding used by standard CNN frameworks.
+    pub fn zero_pad_spatial(&self, pad_h: usize, pad_w: usize) -> Self
+    where
+        T: Default + Copy,
+    {
+        if pad_h == 0 && pad_w == 0 {
+            return self.clone();
+        }
+        let (n, c, h, w) = self.get4d();
+        let new_h = h + 2 * pad_h;
+        let new_w = w + 2 * pad_w;
+        let new_len = n * c * new_h * new_w;
+        let mut data = vec![T::default(); new_len];
+        for ni in 0..n {
+            for ci in 0..c {
+                for hi in 0..h {
+                    for wi in 0..w {
+                        let src = ni * (c * h * w) + ci * (h * w) + hi * w + wi;
+                        let dst_h = hi + pad_h;
+                        let dst_w = wi + pad_w;
+                        let dst =
+                            ni * (c * new_h * new_w) + ci * (new_h * new_w) + dst_h * new_w + dst_w;
+                        data[dst] = self.data[src];
+                    }
+                }
+            }
+        }
+        let new_shape = if self.shape.len() == 3 {
+            Shape::new(vec![c, new_h, new_w])
+        } else {
+            Shape::new(vec![n, c, new_h, new_w])
+        };
+        Tensor::new(new_shape, data)
+    }
+
+    /// Crops a POT-padded tensor back to `target_shape`, extracting only the valid (unpadded)
+    /// spatial data. `target_shape` must be <= the tensor's shape in every dimension.
+    ///
+    /// The tensor is assumed to be 3-D `[C, H_padded, W_padded]` and `target_shape` is
+    /// `[C, H, W]` with `H <= H_padded` and `W <= W_padded`.
+    pub fn crop_to(&self, target_shape: &Shape) -> Self
+    where
+        T: Default + Copy,
+    {
+        assert_eq!(
+            self.shape.len(),
+            target_shape.len(),
+            "crop_to: rank mismatch"
+        );
+        // Fast-path: already the right shape
+        if self.shape == *target_shape {
+            return self.clone();
+        }
+        assert_eq!(target_shape.len(), 3, "crop_to: only 3-D [C,H,W] supported");
+        let c = target_shape[0];
+        let h = target_shape[1];
+        let w = target_shape[2];
+        let h_padded = self.shape[1];
+        let w_padded = self.shape[2];
+        let mut data = vec![T::default(); c * h * w];
+        for ci in 0..c {
+            for hi in 0..h {
+                for wi in 0..w {
+                    let src = ci * (h_padded * w_padded) + hi * w_padded + wi;
+                    let dst = ci * (h * w) + hi * w + wi;
+                    data[dst] = self.data[src];
+                }
+            }
+        }
+        Tensor::new(target_shape.clone(), data)
+    }
+
     /// Recursively pads the tensor so its ready to be viewed as an MLE
     pub fn pad_next_power_of_two(&self) -> Self {
         self.generic_pad_next_power_of_two(T::default())
@@ -1821,7 +1899,7 @@ impl<T: Default + Clone + Copy> Tensor<T> {
             .chain(self.shape.iter().copied())
             .collect::<Vec<usize>>();
         expansion_shape.iter().zip(padded_shape.iter()).try_for_each(|(&new_dim, &dim)|{
-            // Check new_dim isn't zero 
+            // Check new_dim isn't zero
             if new_dim == 0 {
                 Err(anyhow!("Cannot expand to new shape, new shape dim: {new_dim} was zero"))
             } else if dim != 1 {
@@ -3242,23 +3320,23 @@ mod test {
         let data = vec![
             1.0, 2.0,
 
-            3.0, 4.0, 
-                                  
+            3.0, 4.0,
+
             5.0, 6.0];
 
         let expansion_shape: Shape = vec![3, 3, 2].into();
         #[rustfmt::skip]
         let expansion_data = vec![
-            1.0, 2.0, 
-            1.0, 2.0, 
-            1.0, 2.0, 
-            
-            3.0, 4.0, 
-            3.0, 4.0, 
-            3.0, 4.0, 
-            
-            5.0, 6.0, 
-            5.0, 6.0, 
+            1.0, 2.0,
+            1.0, 2.0,
+            1.0, 2.0,
+
+            3.0, 4.0,
+            3.0, 4.0,
+            3.0, 4.0,
+
+            5.0, 6.0,
+            5.0, 6.0,
             5.0, 6.0,
         ];
 


### PR DESCRIPTION
The ONNX parser rejects any `Conv2D` with `padding != [0,0]`, so the standard "same conv" pattern (`kernel=3, padding=1`) used by ResNet, VGG and most CNNs won't load.

Zero-pads the input before the existing valid-conv circuit. Padding values are public zeros so no new constraint is needed; only `output_shape` has to account for the larger effective input. `Convolution<T>` and `ConvCtx<E>` get an `input_padding: [usize; 2]` field with `#[serde(default)]` so old serialized proofs still deserialize.
